### PR TITLE
Remove unused run: and src/*.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,6 @@ test: src/libmatarith.a
 	$(CC) -o $(MAT_EXEC)     $(ARG_LIBDIR) test/matrix_test.c -lmatarith
 	$(CC) -o $(HANOI_EXEC)   $(ARG_LIBDIR) test/hanoi_test.c  -lmatarith
 	$(CC) -o $(STACK_EXEC)   $(ARG_LIBDIR) test/stack_test.c  -lmatarith
-
-src/*.o : src/*.c
-	$(CC) -c $< -o $@
-
-run: lib test
-	./$(EXEC)
-
+	
 clean:
 	@rm -f src/*.o src/*.a $(HANOI_EXEC) $(MAT_EXEC) $(STACK_EXEC) 


### PR DESCRIPTION
Run: artik kullanmiyorsun cunku $(EXEC) diye bir degisken yok.
src/*.c: ise Makefileda oyle bir tanimlama yok. O tanimlama olmadan kendim yapabiliyor. veya istersen onun yerine 
.c.o: 
	$(CC) $(FLAGS) -c $< -o $@
seklinde yazabilirsinm ama gerek yokmus.